### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Setting up the bot requires basic knowledge of the command line, which is bash o
  7. Aquire a bot token for Discord ([How to create a Discord bot](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token)) and put it in the settings file
  8. Add the Telegram bot to the Telegram chat
    - If the Telegram chat is a supergroup, the bot also needs to be admin of the group, or it won't get the messages. The creator of the supergroup is able to give it admin rights
- 9. Add the Discord bot to the Discord server (https://discordapp.com/oauth2/authorize?&client_id=YOUR_CLIENT_ID_HERE&scope=bot&permissions=0). This requires that you have admin rights on the server
+ 9. Add the Discord bot to the Discord server (https://discordapp.com/oauth2/authorize?client_id=YOUR_CLIENT_ID_HERE&scope=bot&permissions=248832). This requires that you have admin rights on the server
  10. Start TediCross: `npm start`
  11. Ask the bots for the remaining details. In the Telegram chat and the Discord channel, write `@<botname> chatinfo`. Put the info you get in the settings file
  12. Restart TediCross


### PR DESCRIPTION
Adding a bot with `permissions=0` to a private server where the `@everyone` role does not have the rights to read or write messages leads to the bot's inoperability.
Adding a bot with `permissions=248832` will create a managed role for it with the necessary rights that can be edited.

Permissions Calculators:
https://discordapi.com/permissions.html#248832
https://finitereality.github.io/permissions-calculator/?v=248832